### PR TITLE
Add support for XML formated metadata and cursor in resumption Token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   coverage: none
-                  tools: phpunit:8.5
+                  tools: phpunit:9.5
 
             - name: Composer install
               run: "composer install --prefer-dist --no-interaction"

--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ This package provides a wrapper to produce an OAI-PMH endpoint.
 
 ## Note:
 This library is a copy of the abandoned read only repository:
-https://github.com/vitec-memorix/OaiPmh/
+https://github.com/vitec-memorix/OaiPmh/ previous Picturae\Oai-Pmh 
+
+This project aims to support multiple metadata formats like JSON-LD. 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "guzzlehttp/psr7": "^1.2 || ^2.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8 || ^8.5 || ^9.5",
+    "phpunit/phpunit": "^9.5",
     "laminas/laminas-diactoros": "^1.1 || ^2.0",
     "squizlabs/php_codesniffer": "^2.3 || ^3.7",
     "php-coveralls/php-coveralls": "^1.1 || ^2.5",

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/BadArgumentException.php
+++ b/src/Exception/BadArgumentException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/BadResumptionTokenException.php
+++ b/src/Exception/BadResumptionTokenException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/BadVerbException.php
+++ b/src/Exception/BadVerbException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/CannotDisseminateFormatException.php
+++ b/src/Exception/CannotDisseminateFormatException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/IdDoesNotExistException.php
+++ b/src/Exception/IdDoesNotExistException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/MultipleExceptions.php
+++ b/src/Exception/MultipleExceptions.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Exception;

--- a/src/Exception/NoMetadataFormatsException.php
+++ b/src/Exception/NoMetadataFormatsException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/NoRecordsMatchException.php
+++ b/src/Exception/NoRecordsMatchException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Exception/NoSetHierarchyException.php
+++ b/src/Exception/NoSetHierarchyException.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Implementation/JSONLDRecord.php
+++ b/src/Implementation/JSONLDRecord.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Implementation;
@@ -23,25 +23,11 @@ use Kennisnet\OaiPmh\Interfaces\Record as RecordInterface;
 use Kennisnet\OaiPmh\Interfaces\Record\Header;
 use Kennisnet\OaiPmh\XmlSaveString;
 
-/**
- * Class Record
- * Basic implementation of Picturae\OaiPmh\Interfaces\Record
- *
- * @package Picturae\OaiPmh
- */
-class Record implements RecordInterface
+class JSONLDRecord implements RecordInterface
 {
-    private Header         $header;
 
-    private ?XmlSaveString $about;
-
-    private XmlSaveString  $metadata;
-
-    public function __construct(Header $header, XmlSaveString $metadata, XmlSaveString $about = null)
+    public function __construct(private readonly Header $header, private readonly XmlSaveString $metadata, private null|XmlSaveString $about = null)
     {
-        $this->about    = $about;
-        $this->header   = $header;
-        $this->metadata = $metadata;
     }
 
 

--- a/src/Implementation/JsonResumptionToken.php
+++ b/src/Implementation/JsonResumptionToken.php
@@ -9,50 +9,16 @@ use Kennisnet\OaiPmh\Interfaces\ResumptionToken;
 
 class JsonResumptionToken implements ResumptionToken
 {
-    /**
-     * @var int
-     */
-    protected $offset;
-
-    /**
-     * @var int
-     */
-    protected $limit = 100;
-
-    /**
-     * @var DateTimeInterface|null
-     */
-    protected $from;
-
-    /**
-     * @var DateTimeInterface|null
-     */
-    protected $until;
-
-    /**
-     * @var string|null
-     */
-    protected $metadataPrefix;
-
-    /**
-     * @var string|null
-     */
-    protected $set;
 
     public function __construct(
-        int               $offset = 0,
-        int               $limit = 100,
-        DateTimeInterface $from = null,
-        DateTimeInterface $until = null,
-        ?string           $metadataPrefix = null,
-        ?string           $set = null
-    ) {
-        $this->offset         = $offset;
-        $this->limit          = $limit;
-        $this->from           = $from;
-        $this->until          = $until;
-        $this->metadataPrefix = $metadataPrefix;
-        $this->set            = $set;
+        private readonly int $offset = 0,
+        private readonly int $limit = 100,
+        private readonly null|DateTimeInterface $from = null,
+        private readonly null|DateTimeInterface $until = null,
+        private readonly ?string $metadataPrefix = null,
+        private readonly ?string $set = null
+    )
+    {
     }
 
     public static function createFromString(string $jsonResumptionToken): self
@@ -108,12 +74,12 @@ class JsonResumptionToken implements ResumptionToken
     public function encode(): string
     {
         $tokenData = [
-            'from'           => $this->from ? $this->from->getTimestamp() : null,
-            'limit'          => $this->limit(),
-            'until'          => $this->until ? $this->until->getTimestamp() : null,
-            'set'            => $this->set,
-            'offset'         => $this->offset,
-            'metadataPrefix' => $this->metadataPrefix
+            'from' => $this->from?->getTimestamp(),
+            'limit' => $this->limit(),
+            'until' => $this->until?->getTimestamp(),
+            'set' => $this->set,
+            'offset' => $this->offset,
+            'metadataPrefix' => $this->metadataPrefix,
         ];
 
         return base64_encode(json_encode($tokenData) ?: '') ?: '';

--- a/src/Implementation/MetadataFormatType.php
+++ b/src/Implementation/MetadataFormatType.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -24,32 +24,8 @@ use Kennisnet\OaiPmh\Interfaces\MetadataFormatType as MetadataFormatTypeInterfac
 
 class MetadataFormatType implements MetadataFormatTypeInterface
 {
-    /**
-     * @var string
-     */
-    private $namespace;
-
-    /**
-     * @var string
-     */
-    private $schema;
-
-    /**
-     * @var string
-     */
-    private $prefix;
-
-
-    /**
-     * @param string $prefix
-     * @param string $schema
-     * @param string $namespace
-     */
-    public function __construct($prefix, $schema, $namespace)
+    public function __construct(private readonly string $prefix, private readonly string $schema, private readonly string $namespace)
     {
-        $this->namespace = $namespace;
-        $this->prefix = $prefix;
-        $this->schema = $schema;
     }
 
 

--- a/src/Implementation/Record/Header.php
+++ b/src/Implementation/Record/Header.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Implementation\Record;
@@ -23,46 +23,16 @@ use DateTime;
 use DateTimeInterface;
 use Kennisnet\OaiPmh\Interfaces\Record\Header as HeaderInterface;
 
-/**
- * Class Header
- * Basic implementation of \Picturae\OaiPmh\Interfaces\Record\Header
- *
- * @package Picturae\OaiPmh\Record
- */
-class Header implements HeaderInterface
+readonly class Header implements HeaderInterface
 {
-    /**
-     * @var string
-     */
-    private $identifier;
-
-    /**
-     * @var DateTimeInterface|null
-     */
-    private $datestamp;
-
-    /**
-     * @var string[]
-     */
-    private $setSpecs;
-
-    /**
-     * @var boolean
-     */
-    private $deleted;
-
-    /**
+     /**
      * Spec values must validate to regex ([A-Za-z0-9\-_\.!~\*'\(\)])+(:[A-Za-z0-9\-_\.!~\*'\(\)]+)*
      * check values with the SetSpecValidator
      *
      * @param string[] $setSpecs
      */
-    public function __construct(string $identifier, ?DateTimeInterface $datestamp, array $setSpecs = [], bool $deleted = false)
+    public function __construct(private string $identifier, private ?DateTimeInterface $datestamp, private array $setSpecs = [],private bool $deleted = false)
     {
-        $this->identifier = $identifier;
-        $this->datestamp  = $datestamp;
-        $this->setSpecs   = $setSpecs;
-        $this->deleted    = $deleted;
     }
 
     public function getIdentifier(): string

--- a/src/Implementation/RecordList.php
+++ b/src/Implementation/RecordList.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Implementation;
@@ -22,47 +22,17 @@ namespace Kennisnet\OaiPmh\Implementation;
 use Kennisnet\OaiPmh\Interfaces\Record as RecordInterface;
 use Kennisnet\OaiPmh\Interfaces\RecordList as RecordListInterface;
 
-/**
- * Class RecordList
- * Basic implementation of Picturae\OaiPmh\Interfaces\RecordList
- *
- * @package Picturae\OaiPmh
- */
 class RecordList implements RecordListInterface
 {
-    /**
-     * @var string|null
-     */
-    private $resumptionToken;
-
-    /**
-     * @var RecordInterface[]
-     */
-    private $items;
-
-    /**
-     * @var int|null
-     */
-    private $completeListSize;
-
-    /**
-     * @var int
-     */
-    private $cursor;
-
     /**
      * @param RecordInterface[] $items
      */
     public function __construct(
-        array   $items,
-        ?string $resumptionToken = null,
-        ?int    $completeListSize = null,
-        int     $cursor = 0
+        private readonly  array   $items,
+        private readonly ?string $resumptionToken = null,
+        private readonly ?int    $completeListSize = null,
+        private readonly  ?int     $cursor = null
     ) {
-        $this->items            = $items;
-        $this->resumptionToken  = $resumptionToken;
-        $this->completeListSize = $completeListSize;
-        $this->cursor           = $cursor;
     }
 
     public function getResumptionToken(): ?string

--- a/src/Implementation/Repository/Identity.php
+++ b/src/Implementation/Repository/Identity.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Implementation\Repository;
@@ -23,12 +23,6 @@ use DateTime;
 use Kennisnet\OaiPmh\Interfaces\Repository\Identity as IdentityInterface;
 use Kennisnet\OaiPmh\XmlSaveString;
 
-/**
- * Class Identity
- * Basic implementation of \Picturae\OaiPmh\Interfaces\Repository\Identity
- *
- * @package Picturae\OaiPmh\Repository
- */
 class Identity implements IdentityInterface
 {
     private string   $repositoryName;

--- a/src/Implementation/Set.php
+++ b/src/Implementation/Set.php
@@ -1,45 +1,30 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Implementation;
 
 use Kennisnet\OaiPmh\Interfaces\Set as SetInterface;
 
-/**
- * Class Set
- * Basic implementation of Picturae\OaiPmh\Interfaces\Set
- *
- * @package Picturae\OaiPmh
- */
 class Set implements SetInterface
 {
-    private string  $spec;
-
-    private string  $name;
-
-    private ?string $description;
-
-    public function __construct(string $spec, string $name, ?string $description = null)
+    public function __construct(private readonly string $spec, private readonly string $name, private readonly ?string $description = null)
     {
-        $this->description = $description;
-        $this->name        = $name;
-        $this->spec        = $spec;
     }
 
 

--- a/src/Implementation/SetList.php
+++ b/src/Implementation/SetList.php
@@ -1,32 +1,26 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Implementation;
 
 use Kennisnet\OaiPmh\Interfaces\Set as SetInterface;
 
-/**
- * Class SetList
- * Basic implementation of Picturae\OaiPmh\Interfaces\SetList
- *
- * @package Picturae\OaiPmh
- */
 class SetList implements \Kennisnet\OaiPmh\Interfaces\SetList
 {
     /**

--- a/src/Implementation/XMLRecord.php
+++ b/src/Implementation/XMLRecord.php
@@ -1,45 +1,64 @@
 <?php
 
 /*
- * This file is part of Kennisnet\OaiPmh.
+ * This file is part of Picturae\OaiPmh.
  *
  * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
+ * Picturae\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Picturae\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace Kennisnet\OaiPmh\Interfaces;
 
-use DOMDocument;
+namespace Kennisnet\OaiPmh\Implementation;
+
+use Kennisnet\OaiPmh\Interfaces\Record as RecordInterface;
 use Kennisnet\OaiPmh\Interfaces\Record\Header;
-use Kennisnet\OaiPmh\XmlSaveString;
 
-interface Record
+/**
+ * Class Record
+ * Basic implementation of Kennisnet\OaiPmh\Interfaces\Record
+ *
+ * @package Kennisnet\OaiPmh
+ */
+class XMLRecord implements RecordInterface
 {
+    public function __construct(private readonly Header $header, private readonly \DOMDocument $metadata, private \DOMDocument|null $about = null)
+    {
+    }
 
     /**
      * contains the unique identifier of the item and properties necessary for selective harvesting.
      */
-    public function getHeader(): Header;
+    public function getHeader(): Header
+    {
+        return $this->header;
+    }
 
     /**
      * an optional and repeatable container to hold data about the metadata part of the record. The contents of an about
      * container must conform to an XML Schema. Individual implementation communities may create XML Schema that define
      * specific uses for the contents of about containers.
      */
-    public function getAbout(): null|XMLSaveString|\DOMDocument;
+    public function getAbout(): ?\DOMDocument
+    {
+        return $this->about;
+    }
 
     /**
      * a single manifestation of the metadata from an item
      */
-    public function getMetadata(): XmlSaveString|DOMDocument;
+    public function getMetadata(): \DOMDocument
+    {
+        return $this->metadata;
+    }
 }
+

--- a/src/Interfaces/MetadataFormatType.php
+++ b/src/Interfaces/MetadataFormatType.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -37,7 +37,7 @@ interface MetadataFormatType
     public function getSchema(): string ;
 
     /**
-     * @return string The XML namespace URI that is a global identifier of the metadata format.
+     * The XML namespace URI that is a global identifier of the metadata format.
      */
     public function getNamespace(): string;
 }

--- a/src/Interfaces/Record/Header.php
+++ b/src/Interfaces/Record/Header.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 
@@ -31,7 +31,6 @@ interface Header
     public function getIdentifier(): string;
 
     /**
-     * @return DateTimeInterface
      * the date of creation, modification or deletion of the record for the purpose of selective harvesting.
      */
     public function getDatestamp(): DateTimeInterface;

--- a/src/Interfaces/RecordList.php
+++ b/src/Interfaces/RecordList.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/Interfaces/Repository.php
+++ b/src/Interfaces/Repository.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Interfaces;
@@ -25,12 +25,11 @@ use Kennisnet\OaiPmh\Interfaces\Repository\Identity;
 interface Repository
 {
     /**
-     * @return string the base URL of the repository
+     * the base URL of the repository
      */
     public function getBaseUrl(): string;
 
     /**
-     * @return string
      * the finest harvesting granularity supported by the repository. The legitimate values are
      * YYYY-MM-DD and YYYY-MM-DDThh:mm:ssZ with meanings as defined in ISO8601.
      */

--- a/src/Interfaces/Repository/Identity.php
+++ b/src/Interfaces/Repository/Identity.php
@@ -1,24 +1,25 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Interfaces\Repository;
 
+use DateTimeInterface;
 use Kennisnet\OaiPmh\XmlSaveString;
 
 interface Identity
@@ -46,19 +47,17 @@ interface Identity
     const DELETED_RECORD_TRANSIENT = 'transient';
 
     /**
-     * @return string
      * a human readable name for the repository
      */
-    public function getRepositoryName();
+    public function getRepositoryName(): string;
 
     /**
-     * @return \DateTime
      * a datetime that is the guaranteed lower limit of all datestamps recording changes,modifications, or deletions
      * in the repository. A repository must not use datestamps lower than the one specified
      * by the content of the earliestDatestamp element. earliestDatestamp must be expressed at the finest granularity
      * supported by the repository.
      */
-    public function getEarliestDatestamp();
+    public function getEarliestDatestamp(): DateTimeInterface;
 
     /**
      * the manner in which the repository supports the notion of deleted records. Legitimate values are:

--- a/src/Interfaces/ResultList.php
+++ b/src/Interfaces/ResultList.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Interfaces;

--- a/src/Interfaces/Set.php
+++ b/src/Interfaces/Set.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Interfaces;

--- a/src/Interfaces/SetList.php
+++ b/src/Interfaces/SetList.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/src/ResponseDocument.php
+++ b/src/ResponseDocument.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh;
@@ -25,32 +25,18 @@ use GuzzleHttp\Psr7\Response;
 use Kennisnet\OaiPmh\Exception\NoRecordsMatchException;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * Class ResponseDocument
- * @internal
- */
 class ResponseDocument
 {
-
-    /**
-     * @var string
-     */
-    private $output;
+    private string $output;
 
     /**
      * @var string[]
      */
-    private $headers = ['Content-Type' => 'text/xml; charset=utf8'];
+    private array $headers = ['Content-Type' => 'text/xml; charset=utf8'];
 
-    /**
-     * @var string
-     */
-    private $status = '200';
+    private string $status = '200';
 
-    /**
-     * @var DOMDocument
-     */
-    private $document;
+    private DOMDocument $document;
 
     public function getDocument(): DOMDocument
     {

--- a/src/Validator/SetSpecValidator.php
+++ b/src/Validator/SetSpecValidator.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Kennisnet\OaiPmh\Validator;

--- a/src/Validator/ValidatorInterface.php
+++ b/src/Validator/ValidatorInterface.php
@@ -1,20 +1,20 @@
 <?php
 
 /*
- * This file is part of Picturae\Oai-Pmh.
+ * This file is part of Kennisnet\OaiPmh.
  *
- * Picturae\Oai-Pmh is free software: you can redistribute it and/or modify
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Picturae\Oai-Pmh is distributed in the hope that it will be useful,
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Picturae\Oai-Pmh.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -1,0 +1,755 @@
+<?php
+
+/*
+ * This file is part of Kennisnet\OaiPmh.
+ *
+ * Kennisnet\OaiPmh is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Kennisnet\OaiPmh is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Kennisnet\OaiPmh.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+namespace Test\Kennisnet\OaiPmh;
+
+use Kennisnet\OaiPmh\Implementation\XMLRecord;
+use Kennisnet\OaiPmh\Provider;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Kennisnet\OaiPmh\Exception\BadResumptionTokenException;
+use Kennisnet\OaiPmh\Exception\IdDoesNotExistException;
+use Kennisnet\OaiPmh\Implementation\MetadataFormatType;
+use Kennisnet\OaiPmh\Implementation\Record\Header;
+use Kennisnet\OaiPmh\Implementation\RecordList;
+use Kennisnet\OaiPmh\Implementation\Repository\Identity;
+use Kennisnet\OaiPmh\Implementation\Set;
+use Kennisnet\OaiPmh\Implementation\SetList;
+use Psr\Http\Message\ResponseInterface;
+
+class ProviderTest extends TestCase
+{
+    private function getProvider(): Provider
+    {
+        $mock = $this->getRepo();
+        return new Provider($mock);
+    }
+
+    public function testNoVerb(): void
+    {
+        $repo = $this->getProvider();
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badVerb']");
+    }
+
+    public function testBadVerb(): void
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'badverb']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badVerb']");
+    }
+
+    public function testMultipleVerbs(): void
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'badverb']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badVerb']");
+    }
+
+    public function testBadArguments(): void
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'Identify',
+            'nonExistingArg' => '1',
+            'nonExistingArg2' => '1'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument'][1]");
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument'][2]");
+    }
+
+    private function assertXPathExists(ResponseInterface $response, $query): void
+    {
+        $document = new \DOMDocument();
+        $document->loadXML($response->getBody());
+
+        $xpath = new \DOMXPath($document);
+        $xpath->registerNamespace("oai", 'http://www.openarchives.org/OAI/2.0/');
+
+        $this->assertTrue(
+            $this->xpathExists($response, $query),
+            "Didn't find expected element $query:\n" . $response->getBody()
+        );
+    }
+
+    private function assertXPathNotExists(ResponseInterface $response, $query): void
+    {
+        $this->assertTrue(
+            !$this->xpathExists($response, $query),
+            "Found elements using query $query:\n" . $response->getBody()
+        );
+    }
+
+    private function xpathExists(ResponseInterface $response, string $query): bool
+    {
+        $document = new \DOMDocument();
+        $document->loadXML($response->getBody());
+
+        $xpath = new \DOMXPath($document);
+        $xpath->registerNamespace("oai", 'http://www.openarchives.org/OAI/2.0/');
+        return $xpath->query($query)->length > 0;
+    }
+
+    private function assertValidResponse(ResponseInterface $response): void
+    {
+        $document = new \DOMDocument();
+        $document->loadXML($response->getBody());
+
+        $schemaLocation = $document->documentElement->getAttributeNS(
+            'http://www.w3.org/2001/XMLSchema-instance',
+            'schemaLocation'
+        );
+        $xsd = explode(" ", $schemaLocation)[1];
+
+        $this->assertMatchesRegularExpression(
+            '#^[1-5]\d{2}$#',
+            (string)$response->getStatusCode(),
+            "invalid status code: " . $response->getStatusCode()
+        );
+
+        if ($this->xpathExists($response, '//oai:error')) {
+            $this->assertMatchesRegularExpression(
+                '#^4\d{2}$#',
+                (string)$response->getStatusCode(),
+                "Expected some kind of 4xx header found: " . $response->getStatusCode()
+            );
+        }
+
+        try {
+            $this->assertTrue($document->schemaValidate($xsd));
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage() . " in:\n" . $response->getBody());
+        }
+    }
+
+    public function testIdentify()
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'Identify']));
+        $response = $repo->getResponse();
+
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:Identify");
+        $this->assertValidResponse($response);
+    }
+
+    public function testPost()
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withParsedBody(['verb' => 'Identify'])->withMethod('POST'));
+        $response = $repo->getResponse();
+
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:Identify");
+        $this->assertValidResponse($response);
+    }
+
+    public function testListMetadataFormats()
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'ListMetadataFormats']));
+        $response = $repo->getResponse();
+
+
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:ListMetadataFormats");
+        $this->assertValidResponse($response);
+    }
+
+    public function testListMetadataFormatsWithIdentifier()
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListMetadataFormats',
+            'identifier' => 'a'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListMetadataFormats',
+            'identifier' => 'b'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='noMetadataFormats']");
+        $this->assertValidResponse($response);
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListMetadataFormats',
+            'identifier' => 'c'
+        ]));
+        $response = $repo->getResponse();
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='idDoesNotExist']");
+
+        $this->assertValidResponse($response);
+    }
+
+    public function testListSets()
+    {
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'ListSets']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'ListSets', 'resumptionToken' => 'a']));
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:ListSets/oai:set");
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:ListSets/oai:resumptionToken");
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'ListSets', 'resumptionToken' => 'b']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:ListSets/oai:resumptionToken");
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'ListSets', 'resumptionToken' => 'c']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badResumptionToken']");
+    }
+
+    public function testListRecords()
+    {
+        //bad date in Y-m-d format
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'ListRecords', 'from' => '2345-44-56']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //metadata prefix missing
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListRecords',
+            'from' => '2345-01-01T12:12+00'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //metadata prefix wrong
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListRecords',
+            'metadataPrefix' => 'oai_custom',
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='cannotDisseminateFormat']");
+
+        //bad date
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListRecords',
+            'from' => '2345-31-12T12:12:00Z',
+            'metadataPrefix' => 'oai_dc'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //valid request
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListRecords',
+            'from' => '2345-01-01T12:12:00Z',
+            'metadataPrefix' => 'oai_dc'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:error");
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:ListRecords/oai:resumptionToken");
+        $this->assertXPathExists(
+            $response,
+            "/oai:OAI-PMH/oai:ListRecords/oai:resumptionToken[@cursor=\"0\"]"
+        );
+        $this->assertXPathExists(
+            $response,
+            "/oai:OAI-PMH/oai:ListRecords/oai:resumptionToken[@completeListSize=\"100\"]"
+        );
+
+        //do a request with an invalid date
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListRecords',
+            'from' => '2345-31-12',
+            'metadataPrefix' => 'oai_dc'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+        $this->assertValidResponse($response);
+    }
+
+    public function testGetRecord()
+    {
+        //no identifier
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'GetRecord',
+            'metadataPrefix' => 'oai_dc'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //no metadataPrefix
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams(['verb' => 'GetRecord', 'identifier' => 'a']));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //metadata prefix wrong
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'GetRecord',
+            'identifier' => 'a',
+            'metadataPrefix' => 'oai_custom',
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='cannotDisseminateFormat']");
+
+        //valid request
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'GetRecord',
+            'metadataPrefix' => 'oai_dc',
+            'identifier' => 'a'
+        ]));
+        $response = $repo->getResponse();
+
+        // @TODO The schema validation does not work properly in that case.
+        // Fix schema validation and enable this test again.
+        // @see https://github.com/picturae/OaiPmh/issues/2
+//        $this->assertValidResponse($response);
+
+        $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //valid request
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'GetRecord',
+            'metadataPrefix' => 'oai_dc',
+            'identifier' => 'b'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:error[@code='IdDoesNotExistException']");
+    }
+
+    public function testListIdentifiers()
+    {
+        //metadata prefix missing
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //metadata prefix wrong
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_custom',
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='cannotDisseminateFormat']");
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2345-44-56'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        // different form and until granularity in one request
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2012-02-12',
+            'until' => '2012-04-12T12:00:00Z'
+        ]));
+        $response = $repo->getResponse();
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2012-02-12T12:00:00Z',
+            'until' => '2012-04-12'
+        ]));
+        $response = $repo->getResponse();
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        // from after until
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2012-06-12',
+            'until' => '2012-04-12'
+        ]));
+        $response = $repo->getResponse();
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        // From before until
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2012-02-12',
+            'until' => '2012-04-12'
+        ]));
+        $response = $repo->getResponse();
+        $this->assertValidResponse($response);
+        $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2345-31-12'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //we don't allow ++00
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2345-01-01T12:12:00+00'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:error[@code='badArgument']");
+
+        //valid request
+        $repo = $this->getProvider();
+        $repo->setRequest((new ServerRequest())->withQueryParams([
+            'verb' => 'ListIdentifiers',
+            'metadataPrefix' => 'oai_dc',
+            'from' => '2345-01-01T12:12:00Z'
+        ]));
+        $response = $repo->getResponse();
+
+        $this->assertValidResponse($response);
+        $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:error");
+        $this->assertXPathExists($response, "/oai:OAI-PMH/oai:ListIdentifiers/oai:resumptionToken");
+        $this->assertXPathExists(
+            $response,
+            "/oai:OAI-PMH/oai:ListIdentifiers/oai:resumptionToken[@cursor=\"0\"]"
+        );
+        $this->assertXPathExists(
+            $response,
+            "/oai:OAI-PMH/oai:ListIdentifiers/oai:resumptionToken[@completeListSize=\"100\"]"
+        );
+    }
+
+    public function testDeletedRecords()
+    {
+        $requests = [
+            // In list records
+            (new ServerRequest())->withQueryParams([
+                'verb' => 'ListRecords',
+                'metadataPrefix' => 'oai_dc',
+                'set' => 'deleted:set',
+            ]),
+
+            // In list identifiers
+            (new ServerRequest())->withQueryParams([
+                'verb' => 'ListIdentifiers',
+                'metadataPrefix' => 'oai_dc',
+                'set' => 'deleted:set',
+            ]),
+
+            // In get record
+            (new ServerRequest())->withQueryParams([
+                'verb' => 'GetRecord',
+                'metadataPrefix' => 'oai_dc',
+                'identifier' => 'deleted',
+            ]),
+        ];
+
+        foreach ($requests as $request) {
+            $repo = $this->getProvider();
+            $repo->setRequest($request);
+            $response = $repo->getResponse();
+
+            $this->assertValidResponse($response);
+            $this->assertXPathNotExists($response, "/oai:OAI-PMH/oai:error");
+            $this->assertXPathExists($response, "//oai:header[@status='deleted']");
+            $this->assertXPathNotExists($response, "//oai:metadata");
+            $this->assertXPathNotExists($response, "//oai:about");
+        }
+    }
+
+    private function getRepo()
+    {
+        $mock = $this->getMockBuilder('\Kennisnet\OaiPmh\Interfaces\Repository')->getMock();
+
+//        $description = new \DOMDocument();
+//        $description->loadXML('<eprints
+//                     xmlns="http://www.openarchives.org/OAI/1.1/eprints"
+//                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+//                     xsi:schemaLocation="http://www.openarchives.org/OAI/1.1/eprints
+//                     http://www.openarchives.org/OAI/1.1/eprints.xsd">
+//                    <content>
+//                      <URL>http://memory.loc.gov/ammem/oamh/lcoa1_content.html</URL>
+//                      <text>Selected collections from American Memory at the Library
+//                            of Congress</text>
+//                    </content>
+//                    <metadataPolicy/>
+//                    <dataPolicy/>
+//                    </eprints>'
+//        );
+        $mock->expects($this->any())->method('identify')->will(
+            $this->returnValue(
+                new Identity(
+                    'testRepo',
+                    new \DateTime(),
+                    \Kennisnet\OaiPmh\Interfaces\Repository\Identity::DELETED_RECORD_PERSISTENT,
+                    ["email@example.com"],
+                    \Kennisnet\OaiPmh\Interfaces\Repository\Identity::GRANULARITY_YYYY_MM_DDTHH_MM_SSZ,
+                    'gzip'
+                )
+            )
+        );
+
+        $listFormats = function ($identifier = null) {
+            switch ($identifier) {
+                case "a":
+                case "deleted":
+                case null:
+                    return [
+                        new MetadataFormatType(
+                            "oai_dc",
+                            'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
+                            'http://www.openarchives.org/OAI/2.0/oai_dc/'
+                        ),
+                        new MetadataFormatType(
+                            "olac",
+                            'http://www.language-archives.org/OLAC/olac-0.2.xsd',
+                            'http://www.language-archives.org/OLAC/0.2/'
+                        ),
+                    ];
+                case "b":
+                    return [];
+                case "c":
+                    throw new IdDoesNotExistException(
+                        "The value of the identifier argument is unknown or illegal in this repository."
+                    );
+            }
+        };
+
+        $mock->expects($this->any())->method('listMetadataFormats')->will(
+            $this->returnCallback($listFormats)
+        )->with();
+
+
+        $setList = new SetList(
+            [
+                new Set("a", "set A"),
+                new Set("b", "set B"),
+            ],
+            'resumptionToken'
+        );
+
+        $mock->expects($this->any())->method('listSets')->will(
+            $this->returnValue($setList)
+        )->with();
+
+        $mock->expects($this->any())->method('listSetsByToken')->will(
+            $this->returnCallback(
+                function ($token) use ($setList) {
+                    if ($token == "a") {
+                        return $setList;
+                    } elseif ($token == "a") {
+                        return new SetList(
+                            [
+                                new Set("a", "set A"),
+                                new Set("b", "set B"),
+                            ]
+                        );
+                    } else {
+                        throw new BadResumptionTokenException(
+                            "The value of the resumptionToken argument is invalid or expired."
+                        );
+                    }
+                }
+            )
+        )->with();
+
+        $recordMetadata = new \DOMDocument();
+        $recordMetadata->loadXML(
+            '
+            <oai_dc:dc
+                 xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                 xmlns:dc="http://purl.org/dc/elements/1.1/"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                 http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                <dc:title>Using Structural Metadata to Localize Experience of
+                          Digital Content</dc:title>
+                <dc:creator>Dushay, Naomi</dc:creator>
+                <dc:subject>Digital Libraries</dc:subject>
+                <dc:description>With the increasing technical sophistication of
+                    both information consumers and providers, there is
+                    increasing demand for more meaningful experiences of digital
+                    information. We present a framework that separates digital
+                    object experience, or rendering, from digital object storage
+                    and manipulation, so the rendering can be tailored to
+                    particular communities of users.
+                </dc:description>
+                <dc:description>Comment: 23 pages including 2 appendices,
+                    8 figures</dc:description>
+                <dc:date>2001-12-14</dc:date>
+            </oai_dc:dc>'
+        );
+
+        $someRecord = new XMLRecord(new Header("id1", new \DateTime()), $recordMetadata);
+
+        $deletedRecordMetadata = new \DOMDocument();
+        $deletedRecordMetadata->loadXML(
+            '
+            <oai_dc:dc
+                 xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                 xmlns:dc="http://purl.org/dc/elements/1.1/"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/
+                 http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                <dc:title>Deleted record</dc:title>
+                <dc:description>A testing deleted record</dc:description>
+                <dc:date>2001-01-01</dc:date>
+            </oai_dc:dc>'
+        );
+
+        $deletedRecord = new XMLRecord(
+            new Header("deleted", new \DateTime(), [], true),
+            $deletedRecordMetadata
+        );
+
+        $listRecords = function (
+            int                $limit,
+            int                $offset,
+            ?string            $metadataFormat,
+            ?\DateTimeInterface $from = null,
+            ?\DateTimeInterface $until = null,
+            ?string             $set = null
+        ) use (
+            $someRecord,
+            $deletedRecord
+        ) {
+            $kip = func_get_args();
+
+            switch ($set) {
+                case 'deleted:set':
+                    return new RecordList(
+                        [
+                            $deletedRecord,
+                        ],
+                        'resumptionToken',
+                        100,
+                        0
+                    );
+                default:
+                    return new RecordList(
+                        [
+                            $someRecord,
+                            $deletedRecord,
+                        ],
+                        'resumptionToken',
+                        100,
+                        0
+                    );
+            }
+        };
+
+        $mock->expects($this->any())->method('listRecords')->will(
+            $this->returnCallback($listRecords)
+        )->with();
+
+
+        $getRecords = function ($metadataFormat = null, $identifier = null) use ($someRecord, $deletedRecord) {
+            switch ($identifier) {
+                case "a":
+                    return $someRecord;
+                case "deleted":
+                    return $deletedRecord;
+                default:
+                    throw new IdDoesNotExistException(
+                        "The value of the identifier argument is unknown or illegal in this repository."
+                    );
+            }
+        };
+
+        $mock->expects($this->any())->method('getRecord')->will(
+            $this->returnCallback($getRecords)
+        )->with();
+
+        return $mock;
+    }
+}
+


### PR DESCRIPTION
This PR aims to brings back the original XML metadata format support. 

Current implementation only support JSON-LD or any other Stringable types as metadata record after these changes XML Types are possible again.

There are some breaking changes in the classname of the Record implementation. Now there are 2 separate classes for Non XML Metadata records and XML Metadata records. A stratigy should be discussed if we accept this BC or there needs to be a backwards compatibility layer / feature flag?

As kennisnet we aiming to keep proper support for newer PHP versions, so most of the newer PHP-8 features are used where possible. 

With all the change some boy scouting has been done: 
Code cleanup to PHP 8 standaards, renamed Picturae\Oai-Pmh to Kennisnet|OaiPmh namespaces in doc and copyright and used types where possible 